### PR TITLE
add unicode-range property to font-face css

### DIFF
--- a/scss/oldhungarian.scss
+++ b/scss/oldhungarian.scss
@@ -5,5 +5,6 @@
 	src: local('☺'), url('fonts/OldHungarian.woff') format('woff'), url('fonts/OldHungarian.ttf') format('truetype'), url('fonts/OldHungarian.svg') format('svg');
 	font-weight: normal;
 	font-style: normal;
+	unicode-range: U+10C80-10CFF;
 }
 


### PR DESCRIPTION
This allows CSS such as:

``` css
p {
  font-family: 'Web_OldHungarian', Helvetica, sans-serif;
}
```

without needing to mark the runic text separately
